### PR TITLE
Added the adafruit rfm69 dependency to the pip requirements list      

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 PyQt5~=5.15.4
 pyserial~=3.5
 future~=0.18.2
+adafruit-circuitpython-rfm69~=2.1.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 PyQt5~=5.15.4
 pyserial~=3.5
 future~=0.18.2
-adafruit-circuitpython-rfm69~=2.1.6
+adafruit-circuitpython-rfm69~=2.1.5


### PR DESCRIPTION
Hi, really interesting project. 
I think that the current pip requirements list is missing the adafruit rfm69 package required by comms.py, I noticed as I was getting the workspace setup.
Since version 2.1.5 of the adafruit rfm69 package was released around the time the rfm69 code was pulled into main, I added that to the requirements list.